### PR TITLE
[Bugfix] Fixed deadlock issue

### DIFF
--- a/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStep.java
+++ b/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStep.java
@@ -129,6 +129,17 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 	 * For each row, create a new output row in the model of the master output row and copy the data values in to the
 	 * appropriate indexes
 	 *
+	 * Step Overview
+	 *
+	 * The step works by getting the meta information about each of the incoming infostreams and creating a mapping
+	 * for each of these infostreams to the single outputstream. The step needs to wait for the meta information from
+	 * each of the infostreams or the signal from that stream that no rows are coming. Due to the BlockRowSet
+	 * architecture that connects steps in Kettle, you can reach a deadlock if the BlockingRowSet gets full before
+	 * each of the infostreams has sent its meta information. Because of this, there may be a need to copy rows to disk
+	 * during the setup phase until we get meta information from each row. Once we've created the mapping structure,
+	 * we read any rows we've written to disk and then start reading rows normally.
+	 *
+	 *
 	 * @param smi the step meta interface containing the step settings
 	 * @param sdi the step data interface that should be used to store
 	 *

--- a/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStep.java
+++ b/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStep.java
@@ -10,7 +10,7 @@
 * you may not use this file except in compliance with
 * the License. You may obtain a copy of the License at
 *
-*    http://www.apache.org/licenses/LICENSE-2.0
+*	http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
@@ -71,8 +71,8 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 	 * @param dis				transformation executing
 	 */
 	public StreamSchemaStep(StepMeta s, StepDataInterface stepDataInterface, int c, TransMeta t, Trans dis) {
-        super(s, stepDataInterface, c, t, dis);
-        dis.setSafeModeEnabled(false);  // safe mode is incompatible with this step
+		super(s, stepDataInterface, c, t, dis);
+		dis.setSafeModeEnabled(false);  // safe mode is incompatible with this step
 	}
 
 	/**
@@ -93,7 +93,7 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 		data.numSteps = data.infoStreams.size();
 		data.rowMetas = new RowMetaInterface[data.numSteps];
 		data.rowSets = new ArrayList<RowSet>();
-        data.stepNames = new ArrayList<String>(data.numSteps);
+		data.stepNames = new ArrayList<String>(data.numSteps);
 		data.inputRowSetNumbers = new LinkedList<Integer>();
 		data.files = new LinkedList<FileObject>();
 		data.outStreams = new ArrayList<ObjectOutputStream>(data.infoStreams.size());
@@ -127,7 +127,7 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 
 	/**
 	 * For each row, create a new output row in the model of the master output row and copy the data values in to the
-     * appropriate indexes
+	 * appropriate indexes
 	 *
 	 * @param smi the step meta interface containing the step settings
 	 * @param sdi the step data interface that should be used to store
@@ -139,15 +139,15 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 		StreamSchemaStepMeta meta = (StreamSchemaStepMeta) smi;
 		StreamSchemaStepData data = (StreamSchemaStepData) sdi;
 
-        /*
-         * Code in first method is responsible for finishing the initialization that we couldn't do earlier
-         */
+		/*
+		 * Code in first method is responsible for finishing the initialization that we couldn't do earlier
+		 */
 		if (first) {
 			first = false;
-            data.foundARowMeta = false;
-            for (int i = 0; i < data.infoStreams.size(); i++) {
+			data.foundARowMeta = false;
+			for (int i = 0; i < data.infoStreams.size(); i++) {
 				data.r = findInputRowSet(data.infoStreams.get(i).getStepname());
-                if (data.r == null) {
+				if (data.r == null) {
 					// see if the rowset has been removed by the calls to getRow below that prevent the step from blocking
 					// in which case we should have stored the relevant info for retrieval
 					if (data.cacheRowMetaMap.containsKey(i)) {
@@ -160,22 +160,22 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 				}
 				data.rowSets.add(data.r);
 				data.stepNames.add(data.r.getName());
-                // Avoids race condition. Row metas are not available until the previous steps have called
-                // putRowWait at least once
-                data.iterations = 0;
+				// Avoids race condition. Row metas are not available until the previous steps have called
+				// putRowWait at least once
+				data.iterations = 0;
 				data.completedLoopedPostDoneSignal = false;
 				data.doneSignal = false;
 				while (data.rowMetas[i] == null && !data.completedLoopedPostDoneSignal && !isStopped()) {
-                    data.rowMetas[i] = data.r.getRowMeta();
-                    data.iterations++;
-                    if (data.doneSignal) {
-                        // we have completed a loop after the done signal
-                        data.completedLoopedPostDoneSignal = true;
-                    }
-                    if (data.r.isDone()) {
-                        // we've received the done signal
-                        data.doneSignal = true;
-                    }
+					data.rowMetas[i] = data.r.getRowMeta();
+					data.iterations++;
+					if (data.doneSignal) {
+						// we have completed a loop after the done signal
+						data.completedLoopedPostDoneSignal = true;
+					}
+					if (data.r.isDone()) {
+						// we've received the done signal
+						data.doneSignal = true;
+					}
 					/*
 					 This step blocks until it gets data from all input row sets (or the rowsets say they're done)
 					 This means that you can encounter issues if you split a stream with a filter, do some action
@@ -219,14 +219,14 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 							throw new KettleException(e.getMessage());
 						}
 					}
-                }
+				}
 
-                if (data.rowMetas[i] != null) {
+				if (data.rowMetas[i] != null) {
 					data.foundARowMeta = true;  // indicates at least one rowset is sending rows
 				}
-                if (isDebug()) {
-                    logDebug("Iterations: " + data.iterations);
-                }
+				if (isDebug()) {
+					logDebug("Iterations: " + data.iterations);
+				}
 			}
 
 			// close output streams and open input streams
@@ -242,21 +242,21 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 				throw new KettleException("Error closing outstreams and opening in streams: " + ex.getMessage());
 			}
 
-            if (!data.foundARowMeta) {
-                // none of the steps are sending rows so indicate we're done
-                setOutputDone();
-                return false;
-            }
+			if (!data.foundARowMeta) {
+				// none of the steps are sending rows so indicate we're done
+				setOutputDone();
+				return false;
+			}
 
 			// set up are mapping structures
 			data.schemaMapping = new SchemaMapper(data.rowMetas);  // creates mapping and master output row
 			data.mapping = data.schemaMapping.getMapping();
 			data.outputRowMeta = data.schemaMapping.getRowMeta();
-            data.convertToString = data.schemaMapping.getConvertToString();
+			data.convertToString = data.schemaMapping.getConvertToString();
 			setInputRowSets(data.rowSets);  // set the order of the inputrowsets to match the order we've defined
-            if (isDetailed()) {
-                logDetailed("Finished generating mapping");
-            }
+			if (isDetailed()) {
+				logDetailed("Finished generating mapping");
+			}
 
 		}
 
@@ -285,8 +285,8 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 			// get the name of the step that the current rowset is coming from
 			data.currentName = getInputRowSets().get(getCurrentInputRowSetNr()).getName();
 		}
-        // because rowsets are removed from the list of rowsets once they're exhausted (in the getRow() method) we
-        // need to use the name to find the proper index for our lookups later
+		// because rowsets are removed from the list of rowsets once they're exhausted (in the getRow() method) we
+		// need to use the name to find the proper index for our lookups later
 		data.streamNum = -1;
 		for (int i = 0; i < data.stepNames.size(); i++) {
 			if (data.stepNames.get(i) != null && data.stepNames.get(i).equals(data.currentName)) {
@@ -298,25 +298,25 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 			throw new KettleException(String.format("Failed to find a matching step name for %s in the stepnames",
 					data.currentName));
 		}
-        if (isRowLevel()) {
-            logRowlevel(String.format("Current row from %s. This maps to stream number %d", data.currentName,
-                    data.streamNum));
-        }
+		if (isRowLevel()) {
+			logRowlevel(String.format("Current row from %s. This maps to stream number %d", data.currentName,
+					data.streamNum));
+		}
 
-        // create a new (empty) output row in the model of the master outputer row
+		// create a new (empty) output row in the model of the master outputer row
 		Object[] outputRow = RowDataUtil.allocateRowData(data.outputRowMeta.size());
 
 		data.rowMapping = data.mapping[data.streamNum];  // set appropriate row mapping
 		data.inRowMeta = data.rowMetas[data.streamNum];  // set appropriate meta for incoming row
 		for (int j = 0; j < data.inRowMeta.size(); j++) {
-            int newPos = data.rowMapping[j];
-            // map a fields old position to its new position
-            if (data.convertToString.contains(newPos) && incomingRow[j] != null) {
-                // we need to convert the underlying data type to string
-                outputRow[newPos] = incomingRow[j].toString();
-            } else {
-                outputRow[newPos] = incomingRow[j];
-            }
+			int newPos = data.rowMapping[j];
+			// map a fields old position to its new position
+			if (data.convertToString.contains(newPos) && incomingRow[j] != null) {
+				// we need to convert the underlying data type to string
+				outputRow[newPos] = incomingRow[j].toString();
+			} else {
+				outputRow[newPos] = incomingRow[j];
+			}
 
 		}
 
@@ -332,28 +332,28 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 		return true;
 	}
 
-    /**
-     * Clear steps from step data
-     * @param smi the step meta interface containing the step settings
-     * @param sdi the step data interface that should be used to store
-     */
-    public void dispose(StepMetaInterface smi, StepDataInterface sdi) {
+	/**
+	 * Clear steps from step data
+	 * @param smi the step meta interface containing the step settings
+	 * @param sdi the step data interface that should be used to store
+	 */
+	public void dispose(StepMetaInterface smi, StepDataInterface sdi) {
 
-        // Casting to step-specific implementation classes is safe
-        StreamSchemaStepMeta meta = (StreamSchemaStepMeta) smi;
-        StreamSchemaStepData data = (StreamSchemaStepData) sdi;
+		// Casting to step-specific implementation classes is safe
+		StreamSchemaStepMeta meta = (StreamSchemaStepMeta) smi;
+		StreamSchemaStepData data = (StreamSchemaStepData) sdi;
 
-        data.outputRowMeta = null;
-        data.inRowMeta = null;
-        data.schemaMapping = null;
-        data.infoStreams = null;
-        data.rowSets = null;
-        data.rowMetas = null;
-        data.mapping = null;
-        data.currentName = null;
-        data.rowMapping = null;
-        data.stepNames = null;
-        data.r = null;
+		data.outputRowMeta = null;
+		data.inRowMeta = null;
+		data.schemaMapping = null;
+		data.infoStreams = null;
+		data.rowSets = null;
+		data.rowMetas = null;
+		data.mapping = null;
+		data.currentName = null;
+		data.rowMapping = null;
+		data.stepNames = null;
+		data.r = null;
 		data.inputRowSetNumbers = null;
 		data.outStreams = null;
 		for (ObjectInputStream is: data.inStreams) {
@@ -367,7 +367,7 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 		data.files = null;
 
 
-        super.dispose(meta, data);
-    }
+		super.dispose(meta, data);
+	}
 
 }

--- a/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStep.java
+++ b/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStep.java
@@ -175,20 +175,26 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 							// keep going
 						}
 						i--; // we want to try this infostream again
+						logBasic(String.format("Retrying infostream %d, for the %d time", i, data.remainingRowSetRetries));
+						continue;
 					} else {
-						throw new KettleException(String.format("Missing a rowset for %s",
-								data.infoStreams.get(i).getStepname()));
+						logBasic(String.format("Missing a rowset for %s, continuing", data.infoStreams.get(i).getStepname()));
 					}
 
 				}
+				data.remainingRowSetRetries = 10;
 				data.rowSets.add(data.r);
-				data.stepNames.add(data.r.getName());
+				if (data.r == null) {
+					data.stepNames.add("");
+				} else {
+					data.stepNames.add(data.r.getName());
+				}
 				// Avoids race condition. Row metas are not available until the previous steps have called
 				// putRowWait at least once
 				data.iterations = 0;
 				data.completedLoopedPostDoneSignal = false;
 				data.doneSignal = false;
-				while (data.rowMetas[i] == null && !data.completedLoopedPostDoneSignal && !isStopped()) {
+				while (data.rowMetas[i] == null && data.r != null && !data.completedLoopedPostDoneSignal && !isStopped()) {
 					data.rowMetas[i] = data.r.getRowMeta();
 					data.iterations++;
 					if (data.doneSignal) {

--- a/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStep.java
+++ b/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStep.java
@@ -23,6 +23,7 @@
 package com.graphiq.kettle.steps.streamschemamerge;
 
 import org.apache.commons.vfs.FileObject;
+import org.apache.commons.vfs.FileSystemException;
 import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.RowDataUtil;
@@ -390,6 +391,13 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 				is.close();
 			} catch (IOException e) {
 				logBasic("Hit exception when cleaning up: " + e.getMessage());
+			}
+		}
+		for (FileObject obj : data.files) {
+			try {
+				obj.delete();
+			} catch (FileSystemException e) {
+				logBasic(String.format("Unable to delete file %s because %s", obj.getName(), e.getMessage()));
 			}
 		}
 		data.outStreams = null;

--- a/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStep.java
+++ b/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStep.java
@@ -167,7 +167,19 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 						data.foundARowMeta = true;
 						continue;
 					}
-					throw new KettleException(String.format("Missing a rowset for %s", data.infoStreams.get(i).getStepname()));
+					if (data.remainingRowSetRetries > 0) {
+						data.remainingRowSetRetries--;
+						try {
+							Thread.sleep(1000);
+						} catch (InterruptedException e) {
+							// keep going
+						}
+						i--; // we want to try this infostream again
+					} else {
+						throw new KettleException(String.format("Missing a rowset for %s",
+								data.infoStreams.get(i).getStepname()));
+					}
+
 				}
 				data.rowSets.add(data.r);
 				data.stepNames.add(data.r.getName());

--- a/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStep.java
+++ b/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStep.java
@@ -223,8 +223,6 @@ public class StreamSchemaStep extends BaseStep implements StepInterface {
 
                 if (data.rowMetas[i] != null) {
 					data.foundARowMeta = true;  // indicates at least one rowset is sending rows
-				} else {
-					logBasic(String.format("No meta found for %d", i));
 				}
                 if (isDebug()) {
                     logDebug("Iterations: " + data.iterations);

--- a/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStepData.java
+++ b/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStepData.java
@@ -22,12 +22,15 @@
 
 package com.graphiq.kettle.steps.streamschemamerge;
 
+import org.apache.commons.vfs.FileObject;
 import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.BaseStepData;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -70,10 +73,15 @@ public class StreamSchemaStepData extends BaseStepData implements StepDataInterf
 
     public Set<Integer> convertToString; // used when we have to resolve data type mismatches
 
-	public LinkedList<Object[]> initialRowBuffer;
+	public LinkedList<Integer> inputRowSetNumbers;
 
-	public LinkedList<Integer> initialRowBufferRowsetNumber;
+	public int ACCUMULATION_TRIGGER = 100000;
 
-	public int ACCUMULATION_TRIGGER;
+	public List<ObjectOutputStream> outStreams;
+
+	public List<ObjectInputStream> inStreams;
+
+	public List<FileObject> files;
+
 }
 	

--- a/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStepData.java
+++ b/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStepData.java
@@ -24,6 +24,7 @@ package com.graphiq.kettle.steps.streamschemamerge;
 
 import org.apache.commons.vfs.FileObject;
 import org.pentaho.di.core.RowSet;
+import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.BaseStepData;
 import org.pentaho.di.trans.step.StepDataInterface;
@@ -33,6 +34,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -63,7 +65,7 @@ public class StreamSchemaStepData extends BaseStepData implements StepDataInterf
 
 	public int[] rowMapping;  // row mapping for the current row
 
-	public String[] stepNames;  // rowset names for incoming rowsets
+	public List<String> stepNames;  // rowset names for incoming rowsets
 
 	public RowSet r;  // used for iterating over rowsets
 
@@ -73,15 +75,25 @@ public class StreamSchemaStepData extends BaseStepData implements StepDataInterf
 
     public Set<Integer> convertToString; // used when we have to resolve data type mismatches
 
-	public LinkedList<Integer> inputRowSetNumbers;
+	public LinkedList<Integer> inputRowSetNumbers;  // row set numbers for the rows written to disk
 
-	public int ACCUMULATION_TRIGGER = 100000;
+	public LinkedList<String> inputRowSetNames;  // row set names for rows written to disk
 
-	public List<ObjectOutputStream> outStreams;
+	public int ACCUMULATION_TRIGGER = 100000;  // the number of iterations before we decide to start writing rows to disk (to prevent blocking)
 
-	public List<ObjectInputStream> inStreams;
+	public List<ObjectOutputStream> outStreams;  // streams for writing cached rows
+
+	public List<ObjectInputStream> inStreams;  // streams for reading cached rows
 
 	public List<FileObject> files;
+
+	public Map<Integer, RowMetaInterface> cacheRowMetaMap;  // lookup for row metas that might get removed when writing rows to disk
+
+	public Map<Integer, String> cacheRowSetNameMap;  // lookup for row set names that might get removed when writing rows to disk
+
+	boolean completedLoopedPostDoneSignal = false;  // this ensures that we run 1 final time after the done signal
+
+	boolean doneSignal = false;  // we can have an infinite loop if a step isn't sending any rows
 
 }
 	

--- a/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStepData.java
+++ b/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStepData.java
@@ -28,6 +28,7 @@ import org.pentaho.di.trans.step.BaseStepData;
 import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -68,5 +69,11 @@ public class StreamSchemaStepData extends BaseStepData implements StepDataInterf
     public int iterations;  // used to track how many loops have occurred looking for rowsets
 
     public Set<Integer> convertToString; // used when we have to resolve data type mismatches
+
+	public LinkedList<Object[]> initialRowBuffer;
+
+	public LinkedList<Integer> initialRowBufferRowsetNumber;
+
+	public int ACCUMULATION_TRIGGER;
 }
 	

--- a/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStepData.java
+++ b/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStepData.java
@@ -91,9 +91,11 @@ public class StreamSchemaStepData extends BaseStepData implements StepDataInterf
 
 	public Map<Integer, String> cacheRowSetNameMap;  // lookup for row set names that might get removed when writing rows to disk
 
-	boolean completedLoopedPostDoneSignal = false;  // this ensures that we run 1 final time after the done signal
+	public boolean completedLoopedPostDoneSignal = false;  // this ensures that we run 1 final time after the done signal
 
-	boolean doneSignal = false;  // we can have an infinite loop if a step isn't sending any rows
+	public boolean doneSignal = false;  // we can have an infinite loop if a step isn't sending any rows
+
+	public int remainingRowSetRetries = 10;
 
 }
 	

--- a/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStepMeta.java
+++ b/src/com/graphiq/kettle/steps/streamschemamerge/StreamSchemaStepMeta.java
@@ -284,9 +284,16 @@ public class StreamSchemaStepMeta extends BaseStepMeta implements StepMetaInterf
 	public void readRep(Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases) throws KettleException  {
 		try{
             int nrSteps = rep.countNrStepAttributes( id_step, "mergeStepName" );
-            for (int i = 0; i < nrSteps; i++) {
-                stepsToMerge.add(rep.getStepAttributeString(id_step, i, "mergeStepName"));
-            }
+			for ( int i = 0; i < nrSteps; i++ ) {
+				getStepIOMeta().addStream(
+						new Stream( StreamInterface.StreamType.INFO, null, "Streams to Merge", StreamIcon.INFO, null ) );
+			}
+			List<StreamInterface> infoStreams = getStepIOMeta().getInfoStreams();
+			for ( int i = 0; i < nrSteps; i++ ) {
+				String name = rep.getStepAttributeString(id_step, i, "mergeStepName");
+				stepsToMerge.add(name);
+				infoStreams.get(i).setSubject(name);
+			}
 		}
 		catch(Exception e){
 			throw new KettleException(BaseMessages.getString(PKG, "StreamSchemaStep.RepoLoadError"), e);

--- a/version.xml
+++ b/version.xml
@@ -1,1 +1,1 @@
-<version branch="Master" buildId="">1.0.1</version>
+<version branch="Master" buildId="">1.1.0</version>


### PR DESCRIPTION
- Step could become deadlocked when merging streams that were being filtered if the first row from one of the input row sets was not in the initial row set
  - e.g. rowset is 10k items and you're reading from 2 streams. First stream sends 10k items before second stream has a chance to send any rows. Job will hang forever waiting for the 2nd rowset to provide a row
- Solution is to take rows of the queue and store them in the Stream Schema step until we get a row or the done signal from all steps
  - In most scenarios this isn't required, but in scenarios where it is the memory usage of the step will increase
  - In an extreme case, you could need to read entire file into memory if you setup a filter that has a scenario that never sends any data
  - Long-term fix needs to set a limit on the size of the in-memory cache at which point data is written to disk (hurting performance but avoiding running out of Heap Space)
